### PR TITLE
Improve Error Message with Defective Value

### DIFF
--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -164,7 +164,7 @@ impl HttpFetch for reqwest::Client {
         let mut req_builder = self
             .request(
                 parts.method,
-                reqwest::Url::from_str(&uri.to_string()).expect("input request url must be valid"),
+                reqwest::Url::from_str(&uri.to_string()).expect(format!("input request url must be valid {}", uri)),
             )
             .headers(parts.headers);
 


### PR DESCRIPTION
The expect message produced here is not ideal.
Here is an example of its presentation.
"input request url must be valid: InvalidIpv4Address"

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6123

# Rationale for this change

It is difficult to correct a defective value if the value is unknown.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Update to an error message.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

The message contains information about a defective uri.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
